### PR TITLE
feat: real commit data and rank

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+yarn.lock
 
 # local env files
 .env*.local


### PR DESCRIPTION
I noticed that the totalCommits field is not the total commits of the selected year, but instead your total commits of the last 365 days (i guess).

As this should be an api for wrapped (showing stats of the year) I added the following fields with correct commit amounts:

- `yearTotalCommits` - Your total commits between the selected year start and end
- `commitRankThisYear` - The rank you would have get for this years total commits